### PR TITLE
CSUB-1089: Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+---
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+
+  # Maintain dependencies for Docker images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+
+  # Maintain dependencies for Rust
+  # Note: Dependabot can't recursively search directories at the moment
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Opening as Draft because I'd like to see some test jobs activated before we start updating dependencies. 